### PR TITLE
Change to use win 32 LoadLibrary32A to fix compiling in Unicode

### DIFF
--- a/src/clew.c
+++ b/src/clew.c
@@ -15,7 +15,7 @@
 
     typedef HMODULE             CLEW_DYNLIB_HANDLE;
 
-    #define CLEW_DYNLIB_OPEN    LoadLibrary
+    #define CLEW_DYNLIB_OPEN    LoadLibraryA
     #define CLEW_DYNLIB_CLOSE   FreeLibrary
     #define CLEW_DYNLIB_IMPORT  GetProcAddress
 #else


### PR DESCRIPTION
test case add two lines in cmakelists.txt
ADD_DEFINITIONS(-DUNICODE)
ADD_DEFINITIONS(-D_UNICODE)

and testclew will pass.
