### PR TITLE
src/clew.c: Fix dlopen() of libOpenCL.so to follow proper ABI

### DIFF
--- a/src/clew.c
+++ b/src/clew.c
@@ -164,7 +164,7 @@ int clewInit()
 #elif defined(__APPLE__)
     const char *path = "/Library/Frameworks/OpenCL.framework/OpenCL";
 #else
-    const char *path = "libOpenCL.so";
+    const char *path = "libOpenCL.so.1";
 #endif
 
     int error = 0;


### PR DESCRIPTION
It is proper to follow the SONAME ABI convention here else
on some systems dlopen() will fail to find the right path.

More precisely, the *.so symlink is only for use by the compile-time
linker and it is generally not available unless the corresponding
development package is installed on the system.

This fixes Blender to find Radeon and Intel GPU's as OpenCL
compute devices.

Signed-off-by: Edward O'Callaghan <funfunctor@folklore1984.net>