### PR TITLE
Fix static build issues and allow user to choose which library do they want

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(clew)
 
 option( BUILD_TESTS "Build test program." ON )
-option( BUILD_SHARED_LIBRARY "Shared library, rather than static library." OFF )
+option( BUILD_SHARED_LIBRARY "Build shared library." OFF )
+option( BUILD_STATIC_LIBRARY "Build static library." OFF )
 option( INSTALL_CL_HEADER "Install cl.h / opencl.h  proxy headers to ease compilation of software not aware of CLEW" OFF )
 
 cmake_minimum_required (VERSION 2.6)
@@ -25,7 +26,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_1_APIS)
-if( NOT BUILD_SHARED_LIBRARY )
+if(BUILD_SHARED_LIBRARY AND BUILD_STATIC_LIBRARY)
+    message(FATAL_ERROR "Choose either BUILD_SHARED_LIBRARY or BUILD_STATIC_LIBRARY, or disable both to rely on global BUILD_SHARED_LIBS")
+endif()
+if(BUILD_STATIC_LIBRARY OR NOT BUILD_SHARED_LIBS)
   add_definitions(-Dclew_STATIC)
 endif()
 
@@ -38,4 +42,3 @@ add_subdirectory(include)
 if( BUILD_TESTS )
   add_subdirectory(clewTest)
 endif( BUILD_TESTS )
-

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ To test it works ok.  You'll need at least one OpenCL-enabled device to do this 
 ## Build options
 
 * BUILD_TESTS: build test executable, default ON
-* BUILD_SHARED_LIBRARY: build dll/so, instead of .lib/.a.  default OFF
+* BUILD_SHARED_LIBRARY: explicitly build dll/so, default OFF
+* BUILD_STATIC_LIBRARY: explicitly build lib/a, default OFF
 * INSTALL_CL_HEADER: creates include files directory `proxy-opencl`, which you can give eg to clBLAS during build, and it will build ok, without needing opencl headers installed
 
+BUILD_SHARED_LIBRARY and BUILD_STATIC_LIBRARY may not be used simultaneously.
+If none of them is on (it's the default), then CMake's global BUILD_SHARED_LIBS
+will be used to decide which type of library to build.

--- a/include/clew.h
+++ b/include/clew.h
@@ -2605,10 +2605,8 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *clGetGLContextInfoKHR_fn)(
   #  define CLEWAPI extern
   #else
   #  ifdef clew_EXPORTS
-#pragma message("exporting")
   #    define CLEWAPI extern __declspec(dllexport)
   #  else
-#pragma message("importing")
   #    define CLEWAPI extern __declspec(dllimport)
   #  endif
   #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,10 @@ SET(MICRO_VERSION 0)
 
 if( BUILD_SHARED_LIBRARY )
   add_library( clew SHARED clew.c )
-else()
+elseif( BUILD_STATIC_LIBRARY )
   add_library( clew STATIC clew.c )
+else()
+  add_library( clew clew.c )
 endif()
 
 set_target_properties(clew

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(MICRO_VERSION 0)
 if( BUILD_SHARED_LIBRARY )
   add_library( clew SHARED clew.c )
 else()
-  add_library( clew clew.c )
+  add_library( clew STATIC clew.c )
 endif()
 
 set_target_properties(clew


### PR DESCRIPTION
CMake does have a global `BUILD_SHARED_LIBS` variable which affects how `add_library()` works. E.g., when `BUILD_SHARED_LIBS=ON` (as it is usually on Windows, where you often link with shared Qt), there was no way to build clew statically, even if `BUILD_SHARED_LIBRARY` is set to `OFF` (which should lead to building a static library, according to documentation).

So, I did a fix that makes clew build like that:
* If either `BUILD_SHARED_LIBRARY` or `BUILD_STATIC_LIBRARY` is set to `ON`, this overrides global `BUILD_SHARED_LIBS` and allows clew to be built either shared or static, regardless of `BUILD_SHARED_LIBS`;
* If both are set to `OFF` (this is now the default), `BUILD_SHARED_LIBS` is used to determine which type of library does user want;
* Library can be built either static or shared, setting both `BUILD_SHARED_LIBRARY` and `BUILD_STATIC_LIBRARY` to `ON` is treated as error.

And also I removed this annoying "exported" message while building a shared library on WIN32, otherwise it really does not look like a warningless build.